### PR TITLE
chore(cargo): update `homepage` to `repository`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Derevtsov Konstantin <godzie@yandex.ru>"]
 description = """
 BugStalker is a modern and lightweight debugger for rust applications.
 """
-homepage = "https://github.com/godzie44/BugStalker"
+repository = "https://github.com/godzie44/BugStalker"
 keywords = ["debugger", "debug", "gdb"]
 categories = ["command-line-utilities", "development-tools::debugging"]
 build = "build.rs"


### PR DESCRIPTION
Change `homepage` key to instead use the [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂