### PR TITLE
docs: add installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ cargo install bugstalker --no-default-features
 ```
 </details>
 
+### Distro Packages
+
+<details>
+  <summary>Packaging status</summary>
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/bugstalker.svg)](https://repology.org/project/bugstalker/versions)
+
+</details>
+
+#### Arch Linux
+
+```shell
+pacman -S bugstalker
+```
+
 ---
 
 ## Start debugger session


### PR DESCRIPTION
Hey! :bear:

I packaged BugStalker for Arch Linux: <https://archlinux.org/packages/extra/x86_64/bugstalker/>

This PR adds the instructions along with a new distro packages section to README.md

Cheers!
