### PR TITLE
Adding homeManager-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,44 @@ For example:
 
 </details>
 
+##### Home-Manager
+There's a home-manager module which adds `programs.bugstalker` to your home-manager config.
+You can add it by doing the following:
+
+<details>
+
+```nix
+{
+  description = "NixOS configuration";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    bugstalker.url = "github:godzie44/BugStalker";
+  };
+
+  outputs = inputs@{ nixpkgs, home-manager, bugstalker, ... }: {
+    nixosConfigurations = {
+      hostname = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ./configuration.nix
+          home-manager.nixosModules.home-manager
+          {
+            home-manager.sharedModules = [
+              bugstalker.homeManagerModules.default
+            ];
+          }
+        ];
+      };
+    };
+  };
+}
+```
+
+</details>
+
 ---
 
 ## Start debugger session

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,10 @@
         };
 
         flake = {
-          homeManagerModules.bugstalker = import ./nix/home-manager-module.nix self;
+          homeManagerModules = rec {
+            default = bugstalker;
+            bugstalker = import ./nix/home-manager-module.nix self;
+          };
         };
       };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,8 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs = inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; }
+  outputs = inputs@{ self, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit self inputs; }
       {
         systems = [
           "x86_64-linux"
@@ -27,7 +27,10 @@
             program = self'.packages.default;
           };
 
-          packages.default = pkgs.callPackage (import ./nix/package.nix) { };
+          packages = rec {
+            default = bugstalker;
+            bugstalker = pkgs.callPackage (import ./nix/package.nix) { };
+          };
 
           devShells.default =
             let
@@ -37,6 +40,10 @@
             pkgs.mkShell {
               packages = [ rust-toolchain ] ++ bs.buildInputs ++ bs.nativeBuildInputs;
             };
+        };
+
+        flake = {
+          homeManagerModules.bugstalker = import ./nix/home-manager-module.nix self;
         };
       };
 }

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -1,0 +1,31 @@
+self: { config, lib, pkgs, ... }:
+with lib;
+let
+  bugstalker = self.packages.${pkgs.stdenv.hostPlatform.system}.bugstalker;
+  pkgs_with_bugstalker = pkgs // { inherit bugstalker; };
+
+  cfg = config.programs.bugstalker;
+  tomlFormat = pkgs.fomrats.toml { };
+in
+{
+  options.programs.bugstalker = {
+    enable = mkEnableOption "Bugstalker";
+
+    package = mkPackageOption pkgs_with_bugstalker "Bugstalker" {
+      default = [ bugstalker.pname ];
+    };
+
+    keymap = mkOption {
+      type = tomlFormat.type;
+      default = { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."bs/keymap.toml" = lib.mkIf (cfg.keymap != { }) {
+      source = (tomlFormat.generate "keymap.toml" cfg.keymap);
+    };
+  };
+}

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -5,7 +5,7 @@ let
   pkgs_with_bugstalker = pkgs // { inherit bugstalker; };
 
   cfg = config.programs.bugstalker;
-  tomlFormat = pkgs.fomrats.toml { };
+  tomlFormat = pkgs.formats.toml { };
 in
 {
   options.programs.bugstalker = {


### PR DESCRIPTION
This adds a home-manager module so that you can easily enable and configure `bugstalker` with it.