### PR TITLE
fix(ci): test with documented rust versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           toolchain: ${{ matrix.rustc_sup_version }}
           override: true
           components: rustfmt, clippy
+      - name: Verify msrv
+        run: "grep '^rust-version = .1.90.0.' Cargo.toml"
       - name: Build test applications for functional testing
         run: make build-examples-for-func-test
       - name: Install actual rustc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bugstalker"
 version = "0.3.4"
 edition = "2024"
+rust-version = "1.90.0"
 license = "MIT"
 authors = ["Derevtsov Konstantin <godzie@yandex.ru>"]
 description = """

--- a/website/docs/support-rustc.mdx
+++ b/website/docs/support-rustc.mdx
@@ -4,6 +4,8 @@ sidebar_position: 3
 
 # Supported rustc versions
 
+Latest released Rust is MSRV for BugStalker itself. This matrix shows versions for the toolchain of code being debugged.
+
 | rustc version       | Supported | Tested* | Bugfixes |
 |---------------------|:---------:|:-------:|:--------:|
 | 1.90                |     ✅     |    ✅    |    ✅     |


### PR DESCRIPTION
We know that [MSRV should be 1.75][msrv] and that 1.85.1-1.89.0 seems to pass in [CI][].

However, that appears to be an illusion as all test runs are accidentally run with 1.89.0. I reality v0.3.3 fails on 1.87.0 due to using features not available until 1.88.0.

This pull request updates the pipeline, but does not address the actual test failures which would occur if merging as is.

Possibly one would like to either adapt the test matrix to only support actually working rust versions, or revert commits breaking compability with older toolschains.

[msrv]: https://godzie44.github.io/BugStalker/docs/support-rustc
[CI]: https://github.com/godzie44/BugStalker/actions/runs/17293183774/job/49085103211