### PR TITLE
fix(build): fail early at compile rather than runtime

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,11 @@
 fn main() {
+    if !(cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") && cfg!(target_env = "gnu")) {
+        panic!(
+            "{} only works with linux using glibc on x86_64",
+            env!("CARGO_PKG_NAME")
+        );
+    }
+
     println!("cargo:rustc-link-arg=-Wl,--export-dynamic");
     println!("cargo:rustc-link-tests=-Wl,--export-dynamic");
 }

--- a/website/docs/overview.md
+++ b/website/docs/overview.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Overview
 
-BugStalker is a modern debugger for Linux x86-64, written in Rust for Rust programs.
+BugStalker is a modern debugger for GNU/Linux x86-64, written in Rust for Rust programs.
 
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import AsciinemaPlayer from '@site/src/components/AsciinemaPlayer';


### PR DESCRIPTION
BugStalker happily builds on Alpine Linux, but attempting to use it fails even for a simple hello world program:

```
% bs target/debug/hello
error: Application error: Build debugger: libthread_db: Could not open library: Error loading shared library libthread_db.so.1: No such file or directory: Could not open library: Error loading shared library libthread_db.so.1: No such file or directory

Usage: bugstalker [OPTIONS] [DEBUGEE] [-- <ARGS>...]

For more information, try '--help'.
```

As far as I have found, there is nothing in the documentation about it requiring glibc. While it does state it to be Linux only, it's easy enough to miss.

This commit adds a simple check to fail compilations early, to help users spend time more constructively than with pointless build attempts. Ideally it could be complemented with deep links to how to improve the portability situation, but I'm not aware of any such existing documentation.