### PR TITLE
fix(debugger): use guard-values for cap of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 ### Changed
 ### Fixed
+
+- debugger: panic when vecdeque have infinite capacity (bug in debug info) 
+
 ### Deprecated
 ### Breaking changes
 

--- a/src/debugger/variable/value/specialization/mod.rs
+++ b/src/debugger/variable/value/specialization/mod.rs
@@ -729,11 +729,11 @@ impl<'a> VariableParserExtension<'a> {
         let cap = if el_type_size == 0 {
             usize::MAX
         } else {
-            extract_capacity(ctx, &val)?
+            guard_cap(extract_capacity(ctx, &val)? as i64) as usize
         };
         let head = val.assume_field_as_scalar_number("head")? as usize;
 
-        let wrapped_start = if head >= cap { head - cap } else { head };
+        let wrapped_start = head % cap;
         let head_len = cap - wrapped_start;
 
         let slice_ranges = if head_len >= len {


### PR DESCRIPTION
vecdeque in specialization module

closes #112