### PR TITLE
chore: update syntect to 5.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,11 +1516,11 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "onig"
-version = "6.4.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1528,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2243,12 +2243,11 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
- "bitflags 1.3.2",
  "flate2",
  "fnv",
  "once_cell",
@@ -2258,7 +2257,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 1.0.38",
+ "thiserror 2.0.12",
  "walkdir",
  "yaml-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ walkdir = "2.3.3"
 timeout-readwrite = "0.3.3"
 tuirealm = { version = "3.0.1" }
 tui-realm-stdlib = { version = "3" }
-syntect = "5.2.0"
+syntect = "5.3.0"
 unicode-width = "0.1.11"
 tui-realm-treeview = { version = "3" }
 capstone = "0.11.0"


### PR DESCRIPTION
This version of synctect upgrades to onig_sys 6.5.1, which fixes the build with GCC 15.

Closes #84.