### PR TITLE
fix(debugger): unwinder no longer stops if there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 ### Changed
 ### Fixed
+
+- debugger: unwinder no longer stops if there is no debug information in some frame of a call stack
+
 ### Deprecated
 ### Breaking changes
 


### PR DESCRIPTION
is no debug information in some frame of a call stack

closes #132