### PR TITLE
Fix Zed extension DAP flag

### DIFF
--- a/extension/zed/src/lib.rs
+++ b/extension/zed/src/lib.rs
@@ -66,13 +66,13 @@ impl zed::Extension for BsExtension {
 
         let (command, arguments) = user_provided_debug_adapter_path
             // TODO how to get arguments if user_provided_debug_adapter_path is defined? (currently its hardcoded)
-            .map(|path| (path, vec!["--dap".into()]))
+            .map(|path| (path, vec!["--dap-local".into()]))
             .or_else(|| {
                 let bs = worktree.which("bs")?;
                 Some((
                     bs,
                     vec![
-                        "--dap".into(),
+                        "--dap-local".into(),
                         "--dap-log-file".into(),
                         "/tmp/bs-zed-1.log".into(),
                     ],


### PR DESCRIPTION
## Summary

- Update the Zed extension to launch BugStalker with `--dap-local` instead of the obsolete `--dap` flag.
- Preserve the existing `/tmp/bs-zed-1.log` DAP log argument for PATH-discovered `bs` installs.

## Rationale

Current BugStalker CLI docs and `bs --help` expose stdio DAP mode as `--dap-local`. The Zed extension currently hardcodes `--dap`, causing Zed launches to fail with current `bs` binaries.

## Validation

- Source-level inspection of `bs --help` confirms `--dap-local` is the supported stdio DAP flag.
- Not run: full extension build/tests were not available in the Zed checkout where this patch was prepared.

Release Notes:

- Fixed Zed extension launches with current BugStalker binaries.